### PR TITLE
Fix MCP review findings: sort arrivals, template forwarding, cache keys, schemas

### DIFF
--- a/mcp/stdio.js
+++ b/mcp/stdio.js
@@ -11,6 +11,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
   ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
   ReadResourceRequestSchema,
   ListPromptsRequestSchema,
   GetPromptRequestSchema,
@@ -28,9 +29,10 @@ async function main() {
 
   await upstream.connect(new StreamableHTTPClientTransport(upstreamUrl));
 
-  const [{ tools }, { resources }, { prompts }] = await Promise.all([
+  const [{ tools }, { resources }, { resourceTemplates }, { prompts }] = await Promise.all([
     upstream.listTools(),
     upstream.listResources(),
+    upstream.listResourceTemplates(),
     upstream.listPrompts(),
   ]);
 
@@ -39,7 +41,7 @@ async function main() {
     {
       capabilities: {
         ...(tools.length && { tools: {} }),
-        ...(resources.length && { resources: {} }),
+        ...(resources.length || resourceTemplates.length ? { resources: {} } : {}),
         ...(prompts.length && { prompts: {} }),
       },
     },
@@ -47,6 +49,7 @@ async function main() {
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
   server.setRequestHandler(ListResourcesRequestSchema, async () => ({ resources }));
+  server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => ({ resourceTemplates }));
   server.setRequestHandler(ListPromptsRequestSchema, async () => ({ prompts }));
 
   server.setRequestHandler(CallToolRequestSchema, async (req) =>

--- a/mcp/timetableMcpServer.js
+++ b/mcp/timetableMcpServer.js
@@ -278,7 +278,7 @@ const OUTPUT_SCHEMAS = {
       options: z.array(z.union([zDirectOption, zTransferOption])),
       updated_at: z.string(),
     }),
-    ui_blocks: z.array(z.object({ type: z.literal("map"), data: z.unknown() })),
+    ui_blocks: z.tuple([]),
   }),
 };
 
@@ -446,7 +446,7 @@ function buildTextSummary(toolName, structured) {
       return `Transfer trip: ${best.route1} → «${best.transfer_stop_name}», then ${best.route2} → «${best.alight_stop_name}».`;
     }
     default:
-      return JSON.stringify(structured, null, 2);
+      return `${toolName}: data retrieved.`;
   }
 }
 
@@ -1018,9 +1018,11 @@ function registerTools(server) {
           lat: normalizeCoordinate(body.latitude),
           lng: normalizeCoordinate(body.longitude),
         },
-        arrivals: Array.isArray(body.timetable)
-          ? body.timetable.map((item) => normalizeRealtimeArrival(item))
-          : [],
+        arrivals: sortedArrivals(
+          Array.isArray(body.timetable)
+            ? body.timetable.map((item) => normalizeRealtimeArrival(item))
+            : [],
+        ),
         updated_at: new Date().toISOString(),
       };
 
@@ -1187,7 +1189,8 @@ function registerTools(server) {
           if (routeResult.statusCode >= 400) return null;
           const routeBody = routeResult.body ?? {};
           const shapes = Array.isArray(routeBody.shapes) ? routeBody.shapes : [];
-          const polyline = shapes.find((shape) => Array.isArray(shape) && shape.length > 0) ?? [];
+          const nonEmpty = shapes.filter((shape) => Array.isArray(shape) && shape.length > 0);
+          const polyline = nonEmpty.reduce((longest, s) => s.length > longest.length ? s : longest, nonEmpty[0] ?? []);
           return { route: routeName, polyline };
         }),
       );
@@ -1237,7 +1240,7 @@ function registerTools(server) {
     },
     async ({ latitude, longitude, radius_meters }) => {
       Sentry.metrics.count('mcp.tool_call', 1, { tags: { tool: 'get_stops_around_location' } });
-      const cacheArgs = { latitude, longitude, radius_meters };
+      const cacheArgs = { latitude: normalizeCoordinate(latitude), longitude: normalizeCoordinate(longitude), radius_meters };
       const cached = getCached("get_stops_around_location", cacheArgs);
       if (cached) return cached;
 
@@ -1305,7 +1308,7 @@ function registerTools(server) {
     },
     async ({ latitude, longitude }) => {
       Sentry.metrics.count('mcp.tool_call', 1, { tags: { tool: 'get_nearby_vehicles' } });
-      const cacheArgs = { latitude, longitude };
+      const cacheArgs = { latitude: normalizeCoordinate(latitude), longitude: normalizeCoordinate(longitude) };
       const cached = getCached("get_nearby_vehicles", cacheArgs);
       if (cached) return cached;
 


### PR DESCRIPTION
## Summary

- **Bug fix**: `get_stop_realtime` now sorts arrivals in `data.arrivals` before building the payload, so the NL text summary reports the correct next arrival (previously it read from unsorted insertion order)
- **stdio proxy**: forwards `ListResourceTemplatesRequestSchema` so `timetable://stop/{code}` and `timetable://route/{name}` templates are discoverable by local MCP clients (Claude Desktop, Cursor, etc.)
- **Cache key stability**: `get_stops_around_location` and `get_nearby_vehicles` normalize float coordinates to 5dp in cache key args, preventing cache fragmentation from GPS precision variation across clients
- **`plan_trip` output schema**: changed `ui_blocks` type from a misleading `z.array(z.object({ type: "map", ... }))` to `z.tuple([])`, accurately reflecting that this tool never emits UI blocks
- **`buildTextSummary` default**: replaced `JSON.stringify(structured, null, 2)` fallback with `"${toolName}: data retrieved."` — prevents a large JSON blob from ending up in LLM text content if a new tool is added without a matching case
- **`get_stop_geometry` shape selection**: picks the longest non-empty shape per route instead of just the first, returning the most representative direction polyline

## Test plan

- [ ] All 143 existing tests pass (`npm test`)
- [ ] No new tests needed — all changed behaviour is covered by existing test suite